### PR TITLE
Refactor API routing and update example endpoint in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ docker run --rm -e PROXY_API_KEY=yourkey -e OLLAMA_UPSTREAM=https://ollama.examp
 Test an endpoint:
 
 ```powershell
-curl -X GET "http://127.0.0.1:8000/api/v1/ollama/models" -H "X-API-Key: yourkey"
+curl -X GET "http://127.0.0.1:8000/api/models" -H "X-API-Key: yourkey"
 ```
 
 ## Environment variables

--- a/app/api/v1/endpoints/ollama.py
+++ b/app/api/v1/endpoints/ollama.py
@@ -66,12 +66,13 @@ def _filter_response_headers(headers: Dict[str, str]) -> Dict[str, str]:
 
 
 @router.api_route("/{full_path:path}", methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"])  # type: ignore[arg-type]
-async def proxy(full_path: str, request: Request, _=Depends(verify_api_key)):
+async def proxy(request: Request, _=Depends(verify_api_key)):
     """Proxy any path under this router to the configured UPSTREAM.
 
     Example: POST /api/v1/ollama/models -> forwards to {UPSTREAM}/models
     This preserves query params and most headers but strips Authorization/Host.
     """
+    full_path = request.url.path.replace("/api/", "", 1)
     upstream_url = f"{UPSTREAM.rstrip('/')}/{full_path}"
 
     method = request.method

--- a/app/main.py
+++ b/app/main.py
@@ -17,7 +17,7 @@ def create_app() -> FastAPI:
     )
 
     app.include_router(hello.router, prefix="/api/v1")
-    app.include_router(ollama.router, prefix="/api/v1/ollama")
+    app.include_router(ollama.router, prefix="/api")
 
     return app
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated API routing under /api, moving former /api/v1/ollama endpoints to the new base path. Update any client integrations to use /api for these routes.

* **Documentation**
  * Updated README examples to reflect the new endpoint path, replacing /api/v1/ollama/models with /api/models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->