### PR TITLE
Fix proxy routing and enhance Docker setup with health check and logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,39 @@
-FROM python:3.11-slim
+# --- Build Stage ---
+FROM python:3.11-slim as builder
 
-# Prevent Python from writing .pyc files and buffer stdout/stderr
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 
 WORKDIR /app
 
-# Install build deps (if native wheels are needed) and cleanup apt lists
 RUN apt-get update \
     && apt-get install -y --no-install-recommends build-essential \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Python deps first for better caching
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir --prefix=/install -r requirements.txt
+
+# --- Final Stage ---
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# Create a non-root user
+RUN addgroup --system app && adduser --system --group app
+
+# Copy installed packages from builder
+COPY --from=builder /install /usr/local
 
 # Copy application
 COPY . .
 
+# Change ownership and switch to non-root user
+RUN chown -R app:app /app
+USER app
+
 EXPOSE 8000
 
-# Default command runs uvicorn
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/app/api/v1/endpoints/health.py
+++ b/app/api/v1/endpoints/health.py
@@ -1,0 +1,10 @@
+from fastapi import APIRouter, status
+
+router = APIRouter()
+
+@router.get("/health", status_code=status.HTTP_200_OK)
+async def health_check():
+    """
+    Health check endpoint.
+    """
+    return {"status": "ok"}

--- a/app/api/v1/endpoints/ollama.py
+++ b/app/api/v1/endpoints/ollama.py
@@ -8,6 +8,8 @@ from dotenv import load_dotenv
 from fastapi import APIRouter, Depends, HTTPException, Request
 from starlette.responses import StreamingResponse
 
+from app.ratelimit import limiter
+
 load_dotenv()
 
 # Upstream Ollama server and auth configuration
@@ -66,6 +68,7 @@ def _filter_response_headers(headers: Dict[str, str]) -> Dict[str, str]:
 
 
 @router.api_route("/{full_path:path}", methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"])  # type: ignore[arg-type]
+@limiter.limit("100/minute")
 async def proxy(request: Request, _=Depends(verify_api_key)):
     """Proxy any path under this router to the configured UPSTREAM.
 

--- a/app/logging_config.py
+++ b/app/logging_config.py
@@ -1,0 +1,14 @@
+import logging
+import sys
+
+def setup_logging():
+    """
+    Set up logging for the application.
+    """
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        handlers=[
+            logging.StreamHandler(sys.stdout)
+        ]
+    )

--- a/app/middleware.py
+++ b/app/middleware.py
@@ -1,0 +1,22 @@
+import logging
+import time
+
+from fastapi import Request
+
+logger = logging.getLogger(__name__)
+
+async def log_requests(request: Request, call_next):
+    """
+    Log incoming requests and outgoing responses.
+    """
+    start_time = time.time()
+    
+    response = await call_next(request)
+    
+    process_time = (time.time() - start_time) * 1000
+    
+    logger.info(
+        f"Request: {request.method} {request.url.path} - Response: {response.status_code} - Process Time: {process_time:.2f}ms"
+    )
+    
+    return response

--- a/app/ratelimit.py
+++ b/app/ratelimit.py
@@ -1,0 +1,4 @@
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+limiter = Limiter(key_func=get_remote_address)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-fastapi>=0.95.0
-uvicorn[standard]>=0.22.0
-python-dotenv>=1.0.0
-httpx>=0.24.0
-PyJWT>=2.8.0
+fastapi
+uvicorn
+python-dotenv
+httpx
+pyjwt
+slowapi

--- a/scripts/generate_jwt.py
+++ b/scripts/generate_jwt.py
@@ -1,0 +1,28 @@
+import argparse
+import time
+import jwt
+
+def generate_jwt(secret: str, aud: str = None, iss: str = None) -> str:
+    """
+    Generates a HS256 JWT.
+    """
+    payload = {
+        "iat": int(time.time()),
+        "exp": int(time.time()) + 3600,  # 1 hour expiration
+    }
+    if aud:
+        payload["aud"] = aud
+    if iss:
+        payload["iss"] = iss
+    
+    return jwt.encode(payload, secret, algorithm="HS256")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Generate a HS256 JWT.")
+    parser.add_argument("--secret", required=True, help="The JWT secret.")
+    parser.add_argument("--aud", help="The JWT audience.")
+    parser.add_argument("--iss", help="The JWT issuer.")
+    args = parser.parse_args()
+
+    token = generate_jwt(args.secret, args.aud, args.iss)
+    print(token)


### PR DESCRIPTION
Improve proxy routing logic and implement a multi-stage Docker build. Add a health check endpoint, logging configuration, request logging middleware, and rate limiting to enhance application performance and reliability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Health check endpoint at /api/v1/health returning status “ok”.
  - Rate limiting added to Ollama API routes (e.g., 100/min).
  - Request logging middleware for method, path, status, and latency.
  - CLI script to generate HS256 JWT tokens.

- Chores
  - Docker image now uses a multi-stage build and runs as a non-root user; default start command removed—specify at runtime.
  - Dependencies updated and rate-limiting library added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->